### PR TITLE
fix: resolve GitHub Actions YAML syntax error with template literals

### DIFF
--- a/.github/workflows/close-external-prs.yml
+++ b/.github/workflows/close-external-prs.yml
@@ -14,26 +14,13 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const body = `👋 Thanks for your interest in this repository!
-
-This repository does not accept external pull requests. The maintainers prefer to keep development focused on their specific roadmap and requirements.
-
-📝 **Alternative ways to contribute:**
-- Open an issue with suggestions or bug reports
-- Fork the repository for your own use
-- Star the repo if you find it useful!
-
-🔒 **Repository Policy**
-- Issues: ✅ Open (for feedback, bug reports, suggestions)
-- Pull Requests: ❌ Closed (maintainers only)
-
-Thanks for understanding!`;
+            const message = "👋 Thanks for your interest in this repository!\n\nThis repository does not accept external pull requests. The maintainers prefer to keep development focused on their specific roadmap and requirements.\n\n📝 **Alternative ways to contribute:**\n- Open an issue with suggestions or bug reports\n- Fork the repository for your own use\n- Star the repo if you find it useful!\n\n🔒 **Repository Policy**\n- Issues: ✅ Open (for feedback, bug reports, suggestions)\n- Pull Requests: ❌ Closed (maintainers only)\n\nThanks for understanding!";
 
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: body
+              body: message
             });
 
             await github.rest.pulls.update({


### PR DESCRIPTION
## Summary
Fixes the persistent YAML syntax error in GitHub Actions workflow by removing template literal backticks that were causing parsing issues.

### Root Cause
- JavaScript template literals with backticks don't parse well in YAML
- Multi-line strings with backticks cause GitHub Actions validation to fail

### Fix Applied
- ✅ Replace template literals (` `) with regular string literals (" ")
- ✅ Use escaped newline characters (\n) for line breaks
- ✅ Simplify the message formatting to be YAML-friendly

### Technical Details
- GitHub Actions YAML parser has strict rules about special characters
- Template literals (backticks) are not properly escaped in the YAML context
- Regular JavaScript string literals work reliably within YAML

## Test Plan
- [ ] Verify workflow syntax validation passes
- [ ] Test workflow executes without errors
- [ ] Confirm external PR closure still works correctly

🤖 Generated by [Claude Code](https://claude.ai/claude-code) - GLM 4.6