### PR TITLE
chore: add .draft/ to .gitignore for pre-publish staging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ node_modules
 tina/__generated__/
 tina/tina-lock.json
 
+# Draft posts (held before publish)
+.draft/
+
 # Development editor files
 *.swp
 *.swo


### PR DESCRIPTION
Adds  directory to  so draft posts can be held locally alongside the repo without risk of accidental commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)