### PR TITLE
fix: add hr separator before Co-Authored-By in July articles

### DIFF
--- a/_posts/2026-07-21-the-simplification-paradox.md
+++ b/_posts/2026-07-21-the-simplification-paradox.md
@@ -138,4 +138,6 @@ Sometimes the most powerful prompt engineering is deleting the prompt loop entir
 
 *Next time: the methodology deserves its own treatment. How do you evaluate AI output when there's no ground truth to check against — no right answer, only better and worse judgments? The scoreboard we built for this is a first stab at that harder, more general problem.*
 
+---
+
 🤖 Co-Authored-By: [Claude Code](https://claude.com/product/claude-code) (GLM-5-Turbo)

--- a/_posts/2026-07-23-evaluating-the-unevaluable.md
+++ b/_posts/2026-07-23-evaluating-the-unevaluable.md
@@ -197,4 +197,6 @@ That's enough to start making better decisions about which AI systems to trust. 
 
 *The data — 14 days of head-to-head comparisons — is real, not synthetic. The limitations are stated, not hidden. We think that's how methodology should work.*
 
+---
+
 🤖 Co-Authored-By: [Claude Code](https://claude.com/product/claude-code) (GLM-5-Turbo)


### PR DESCRIPTION
Matches convention from earlier 2026 posts (second hr before attribution line).